### PR TITLE
Misc - Makefile things, a config file fix, and other various bits

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,7 +101,7 @@ out/image-id: Dockerfile tmp/.linted.sentinel
 > echo "$${image_id}" > out/image-id
 
 $(binary_name): tmp/.linted.sentinel
-> go build -v
+> go build -ldflags="-buildid= -w" -trimpath -v
 
 tmp/.benchmarks-ran.sentinel: $(shell find . -type f -iname "*.go")
 > mkdir -p $(@D)

--- a/Makefile
+++ b/Makefile
@@ -84,10 +84,15 @@ tmp/.cover-tests-passed.sentinel: $(shell find . -type f -iname "*.go")
 tmp/.linted.sentinel: Dockerfile .golangci.yaml hack/bin/golangci-lint tmp/.short-tests-passed.sentinel
 > mkdir -p $(@D)
 > docker run --interactive --rm hadolint/hadolint < Dockerfile
-> find . -type f -iname "*.go" -exec gofmt -s -w "{}" +
+> find . -type f -iname "*.go" -exec gofmt -e -l -s "{}" + \
+> | awk '{ print } END { if (NR != 0) { print "gofmt found issues in the above file(s); please run \"make lint-simplify\" to remedy"; exit 1 } }'
 > go vet ./...
 > hack/bin/golangci-lint run
 > touch $@
+
+lint-simplify: ## Runs 'gofmt -s' to format and simplify all Go code.
+> find . -type f -iname "*.go" -exec gofmt -s -w "{}" +
+.PHONY: lint-simplify
 
 hack/bin/golangci-lint:
 > curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \

--- a/TODO.md
+++ b/TODO.md
@@ -56,3 +56,7 @@
   - <https://github.com/actions/starter-workflows/blob/main/ci/docker-image.yml>
   - <https://github.com/actions/starter-workflows/blob/main/ci/docker-publish.yml>
     - further reading: <https://docs.github.com/en/free-pro-team@latest/packages/guides/configuring-docker-for-use-with-github-packages>
+
+## CI pipeline
+
+- [cache Docker builds on GitHub Actions](https://dev.to/dtinth/caching-docker-builds-in-github-actions-which-approach-is-the-fastest-a-research-18ei)

--- a/pkg/cmd/root/config.go
+++ b/pkg/cmd/root/config.go
@@ -54,8 +54,8 @@ func initConfig(cmd *cobra.Command, _ []string) error {
 			return fmt.Errorf("could not get home directory: %w", errHomeDir)
 		}
 
-		// Expect config file name to be "arrowverse.<something>".
-		viper.SetConfigName(cfgName)
+		// Expect a specific config file name.
+		viper.SetConfigName(cfgName + "." + cfgType)
 
 		// Search for a config file in the following order of preference (most preferred first):
 		// - the current working directory


### PR DESCRIPTION
- build(makefile): add self-documentating 'help' target, 'build-binary', and dynamic binary name
- build(go): trim DWARF and path info for smaller and more reproducible binaries
- build(makefile): make 'gofmt' checking and fixing two discrete targets
- docs(todo): save a link for later
- fix(cmd/config): add file extension so that Viper doesn't attempt to read the binary (oops)